### PR TITLE
Fixed mainLooper and snake tail calculations

### DIFF
--- a/modules/Server.js
+++ b/modules/Server.js
@@ -558,8 +558,8 @@ class Server {
                     
                     totalPointLength += segmentLength;
                 }
-                
-                if (totalPointLength > snake.visualLength) {
+
+                while (totalPointLength > snake.visualLength) {
                     let secondToLastPoint = snake.points[snake.points.length - 2] || snake.position;
                     let lastPoint = snake.points[snake.points.length - 1] || snake.position;
                     let direction = MapFunctions.GetNormalizedDirection(secondToLastPoint, lastPoint);
@@ -573,7 +573,9 @@ class Server {
                             y: lastPoint.y - direction.y * amountOverLength
                         }
                         snake.points[snake.points.length - 1] = newPoint;
+                        totalPointLength = snake.visualLength;
                     } else { // Last segment is too short, remove it and decrease the next one
+                        totalPointLength -= lastSegmentLength;
                         snake.points.pop();
                     }
                 }
@@ -601,20 +603,17 @@ class Server {
         const now = Date.now();
         const elapsed = now - this.lastUpdate;
     
-        if (elapsed >= this.config.UpdateInterval) {
-    
-            if (elapsed > this.config.UpdateInterval) {
-                //console.warn(`Server ${this.id} is lagging behind by ${elapsed - this.config.UpdateInterval}ms`);
-            }
-    
-            //console.log(`Executing main loop ${elapsed}ms since last update`);
-    
-            let mainStart = Date.now();
-            this.main();
-            this.lastUpdate = now;
-            //console.log(`Server ${this.id} took ${Date.now() - mainStart}ms to update`);
+        if (elapsed > 1.2 * this.config.UpdateInterval) {
+            console.warn(`Server ${this.id} is lagging behind by ${elapsed - this.config.UpdateInterval}ms`);
         }
-    
+
+        //console.log(`Executing main loop ${elapsed}ms since last update`);
+
+        let mainStart = Date.now();
+        this.main();
+        this.lastUpdate = now;
+        //console.log(`Server ${this.id} took ${Date.now() - mainStart}ms to update`);
+        
         const nextInterval = this.config.UpdateInterval - (Date.now() - this.lastUpdate);
         setTimeout(() => this.mainLooper(), nextInterval);
     }


### PR DESCRIPTION
When removing some of the snake's tail, it is possible that more than one operation is required. Before, only one operation was done per tick: delete/shorten.

The problem with the mainLooper function is that before, if the elapsed time between server ticks was **less** than UpdateInterval, the tick would not be processed. This is a mistake and will ultimately cause a lot of ticks to be lost.

This PR fixes these issues. Please test these fixes. I don't have access to a high ping server.