### PR TITLE
Fixed some bugs with talking

### DIFF
--- a/modules/Client.js
+++ b/modules/Client.js
@@ -270,6 +270,7 @@ class Client extends EventEmitter {
                                     let message = commandArgs.slice(1).join(" ");
                                     message = message.substring(0, 25);
                                     this.snake.flags |= Enums.EntityFlags.SHOW_CUSTOM_TALKING
+                                    this.snake.flags &= ~Enums.EntityFlags.SHOW_TALKING;
                                     this.snake.customTalk = message;
                                     this.snake.talkStamina = 0;
                                     setTimeout(() => {

--- a/modules/Snake.js
+++ b/modules/Snake.js
@@ -528,6 +528,7 @@ class Snake {
         }
     }
     Talk(id) {
+        this.flags &= ~Enums.EntityFlags.SHOW_CUSTOM_TALKING;
         this.flags |= Enums.EntityFlags.SHOW_TALKING;
         this.talkId = id;
         let oldTalkId = id;

--- a/webserver/codenzi/Snake.js
+++ b/webserver/codenzi/Snake.js
@@ -1280,11 +1280,7 @@ var Snake = function () {
 			talkID = view.getUint8(offset, true);
 			offset += 1;
 
-			if(prevTalkID != talkID)
-			{
-				talkText = this.getTalkTextByTalkID(talkID);
-				prevTalkID = talkID;
-			}
+			talkText = this.getTalkTextByTalkID(talkID);
 		}else{
 			talkID = 0;
 		}
@@ -1294,6 +1290,8 @@ var Snake = function () {
 			talkID = 20
 			offset = talkMessage.offset;
 			talkText = talkMessage.nick;
+		}else{
+			talkID = 0;
 		}
 		if (flags & 0x100) // Custom color
 		{


### PR DESCRIPTION
If you tried to talk normally, it would sometimes display the text used in the `say` command that was used earlier. Please review these changes.