### PR TITLE
Fix turn logic

### DIFF
--- a/modules/MapFunctions.js
+++ b/modules/MapFunctions.js
@@ -74,7 +74,7 @@ class MapFunctions {
         return false; 
     }
 
-    static DoIntersect( p1,  q1,  p2,  q2) 
+    static DoIntersect( p1,  q1,  p2,  q2, includeCollinear = false) 
     { 
         // Find the four orientations needed for general and 
         // special cases 
@@ -86,6 +86,8 @@ class MapFunctions {
         // General case 
         if (o1 != o2 && o3 != o4) 
             return true; 
+
+        if (!includeCollinear) return false;
     
         // Special Cases 
         // p1, q1 and p2 are collinear and p2 lies on segment p1q1 

--- a/webserver/codenzi/main.js
+++ b/webserver/codenzi/main.js
@@ -121,6 +121,8 @@ var killStreak = 0;
 var showBigPicture = false;
 var darkenOverlay = false;
 
+window.fixCoord = true;
+
 // Ads
 var readyToRefreshAd = true;
 var refreshAdInterval = 2; // In minutes


### PR DESCRIPTION
This PR fixes all major issues of Calvin's turn logic implementation.

### U turns
Whenever a player does two quick turns during a lag spike, both turns are sent at the same time which results in them sharing the exact same coordinates. This caused an inward turn which is sending you straight into your own snake with no way to escape. The applyGapCorrection method prevents those broken points from being generated in the first place by forcefully pushing the coord into the direction vector of the previous turn if the next turn is within a min threshold.

### Desyncs
There is a race condition where making at least two turns as soon as the previous ones finished processing cause a desync between the client and server side snake. The server will move the head towards the first turn whilst the client is forcefully lerping towards the direction of the second turn. This causes a direction mismatch and the next turn that will be sent will almost always kill your own snake due to teleportation through inaccurate coordinates.
Another factor comes from players rapidly spamming turns, the client prediction could accumulate drift from the server's expected path, causing desyncs where the snake appears in the wrong position. The pathCorrection system now tracks accumulated adjustments across multiple turns and applies them to future turn calculations, this way it ensures that the client stays synchronized with the server during aggressive turn sequences.

### Point breaks
The server sends turn point confirmations in reverse chronological order (newest first). Due to Calvin processing confirmations of turn points inconsistently, the turn points of snakes can be messed up during synchronization periods, especially on lag spikes. The fix ensures all incoming batches of points are properly reversed when added to the pointServerFix queue.